### PR TITLE
Added empty scriptable objects definition for dogs game setup + Changed on Editor setting to speed up entering play mode

### DIFF
--- a/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects.meta
+++ b/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f0aa79acdad6532499d61b68e7073794
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects/DogsSetupScriptableObject.cs
+++ b/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects/DogsSetupScriptableObject.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+
+/// <summary>
+/// This <see cref="ScriptableObject"/> holds all information needed to initialize
+/// a dogs game with arbitrary board state and hand cards.
+/// </summary>
+[CreateAssetMenu(menuName = "ScriptableObjects/DogsSetup")]
+public class DogsSetupScriptableObject : ScriptableObject
+{
+    
+}

--- a/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects/DogsSetupScriptableObject.cs.meta
+++ b/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects/DogsSetupScriptableObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb5d67d720ef44c43afd8317751d2b03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects/TestDogsSetup.asset
+++ b/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects/TestDogsSetup.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb5d67d720ef44c43afd8317751d2b03, type: 3}
+  m_Name: TestDogsSetup
+  m_EditorClassIdentifier: 
+  THis: 0
+  String: 

--- a/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects/TestDogsSetup.asset.meta
+++ b/Avatar - The Legend of VR/Assets/Scripts/ScriptableObjects/TestDogsSetup.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae6d23790fde9934db9ecc8b240d41d0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Avatar - The Legend of VR/ProjectSettings/EditorSettings.asset
+++ b/Avatar - The Legend of VR/ProjectSettings/EditorSettings.asset
@@ -2,10 +2,8 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!159 &1
 EditorSettings:
-  m_AssetPipelineMode: 1
   m_ObjectHideFlags: 0
-  serializedVersion: 10
-  m_ExternalVersionControlSupport: Visible Meta Files
+  serializedVersion: 11
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 0
   m_DefaultBehaviorMode: 0
@@ -13,19 +11,32 @@ EditorSettings:
   m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 0
   m_SpritePackerPaddingPower: 1
+  m_Bc7TextureCompressor: 0
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
   m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef;asmref;rsp
   m_ProjectGenerationRootNamespace: 
-  m_CollabEditorSettings:
-    inProgressEnabled: 1
   m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
   m_AsyncShaderCompilation: 1
-  m_EnterPlayModeOptionsEnabled: 0
-  m_EnterPlayModeOptions: 3
-  m_ShowLightmapResolutionOverlay: 1
+  m_CachingShaderPreprocessor: 1
+  m_PrefabModeAllowAutoSave: 1
+  m_EnterPlayModeOptionsEnabled: 1
+  m_EnterPlayModeOptions: 1
+  m_GameObjectNamingDigits: 1
+  m_GameObjectNamingScheme: 0
+  m_AssetNamingUsesSpace: 1
   m_UseLegacyProbeSampleCount: 0
   m_SerializeInlineMappingsOnOneLine: 1
+  m_DisableCookiesInLightmapper: 1
+  m_AssetPipelineMode: 1
+  m_RefreshImportMode: 0
+  m_CacheServerMode: 0
+  m_CacheServerEndpoint: 
+  m_CacheServerNamespacePrefix: default
+  m_CacheServerEnableDownload: 1
+  m_CacheServerEnableUpload: 1
+  m_CacheServerEnableAuth: 0
+  m_CacheServerEnableTls: 0


### PR DESCRIPTION
* Added empty scriptable objects definition to project. It is intended to be created from us as an Asset and later been passed to the game logic to initialize the game board.
* Changed Enterplaymode setting to not reload the whole Domain (which usually is done to simulate execution after a build as good as possible). Usually, that's not needed and produces a huge overhead and slowdown entering play mode drastically.